### PR TITLE
feat: allow setting priority class

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ module "redis" {
 | `startup_probe_timeout`           | No       | `1`                         | Timeout of the probe in seconds                    |
 | `startup_probe_success`           | No       | `1`                         | Minimum consecutive successes for the probe        |
 | `startup_probe_failure`           | No       | `3`                         | Minimum consecutive failures for the probe         |
+| `priority_class_name`             | No       | `null`                      | Sets a priority class to the pods                  |
 
 ### Service Variables
 

--- a/main.tf
+++ b/main.tf
@@ -58,6 +58,7 @@ resource "kubernetes_stateful_set" "redis" {
         labels = local.selector_labels
       }
       spec {
+        priority_class_name = var.priority_class_name
         dynamic "security_context" {
           for_each = var.security_context_enabled ? [1] : []
           content {

--- a/variables.tf
+++ b/variables.tf
@@ -351,3 +351,9 @@ variable "startup_probe_failure" {
   description = "Minimum consecutive failures for the probe to be considered failed after having succeeded"
   default     = 30
 }
+
+variable "priority_class_name" {
+  type        = string
+  description = "The priority class name for the statefulset"
+  default     = null
+}


### PR DESCRIPTION
## Overview

This adds support for setting the priority class to the pods created by the statefulset 

https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/pod#priority_class_name